### PR TITLE
Fix archive

### DIFF
--- a/archive.md
+++ b/archive.md
@@ -13,8 +13,9 @@ layout: home
     {% assign weeks_array = filtered_dates_array | split: ' ' | uniq | join: ' '  %}
     {% assign weeks = weeks_array | split: ' '%}
     {% for week in weeks %}
-    {% if current_week < week | plus: 0 %}
-      {% current_week = current_week | plus: 52 %}
+    {% assign week_week = week | plus:0 %}
+    {% if current_week < week_week %}
+      {% assign current_week = current_week | plus: 52 %}
     {% endif %}
     {% assign week_num = current_week | minus:week | plus:0 %}
       {% if week_num == 0 %}

--- a/archive.md
+++ b/archive.md
@@ -13,6 +13,9 @@ layout: home
     {% assign weeks_array = filtered_dates_array | split: ' ' | uniq | join: ' '  %}
     {% assign weeks = weeks_array | split: ' '%}
     {% for week in weeks %}
+    {% if current_week < week | plus: 0 %}
+      {% current_week = current_week | plus: 52 %}
+    {% endif %}
     {% assign week_num = current_week | minus:week | plus:0 %}
       {% if week_num == 0 %}
         <section class="week">


### PR DESCRIPTION
This pull request fixes the `Weeks Ago` bug on the archive by checking if the current week number is less than the previous week. If so, add a year (52 weeks) before comparing. Probably not most robust fix.

Fixes #15 